### PR TITLE
Fixed require that wasn't allowing the gem to load with rspec 2.11

### DIFF
--- a/lib/rspec/longrun/core_ext.rb
+++ b/lib/rspec/longrun/core_ext.rb
@@ -1,3 +1,4 @@
+require 'rspec/core'
 require 'rspec/core/example'
 require 'rspec/core/example_group'
 require 'rspec/core/formatters/base_formatter'


### PR DESCRIPTION
I was receiving this error once I included the rspec-longrun gem:

uninitialized constant RSpec::Core::ExampleGroup::MetadataHashBuilder

whenever the gem was loaded.  This was simply a missing require down in the longrun code.  This pull fixes that and makes the error go away.

Cheers
D
