### PR TITLE
typo NOTIFCATIONS -> NOTIFICATIONS

### DIFF
--- a/lib/rspec/longrun/core_ext.rb
+++ b/lib/rspec/longrun/core_ext.rb
@@ -20,7 +20,7 @@ module RSpec::Core
 
   end
 
-  unless defined?(Reporter::NOTIFCATIONS)
+  unless defined?(Reporter::NOTIFICATIONS)
 
     class Formatters::BaseFormatter
 


### PR DESCRIPTION
Hi,

I believe there is a typo and that the constant on line 23 should be `Reporter::NOTIFICATIONS` (an `I` was missing).
