### PR TITLE
Support skip step.

### DIFF
--- a/lib/rspec/longrun/dsl.rb
+++ b/lib/rspec/longrun/dsl.rb
@@ -14,6 +14,11 @@ module RSpec
         end
       end
 
+      def xstep(description)
+        rspec_longrun_formatter.step_started(description)
+        rspec_longrun_formatter.step_pending
+      end
+
       private
 
       def rspec_longrun_formatter

--- a/lib/rspec/longrun/formatter.rb
+++ b/lib/rspec/longrun/formatter.rb
@@ -56,6 +56,10 @@ module RSpec
         end_block(wrap("✗", :failure))
       end
 
+      def step_pending
+        end_block(wrap("PENDING", :pending))
+      end
+
       private
 
       def wrap(*args)

--- a/spec/rspec/longrun/formatter_spec.rb
+++ b/spec/rspec/longrun/formatter_spec.rb
@@ -44,6 +44,11 @@ describe RSpec::Longrun::Formatter do
     formatter.step_finished
   end
 
+  def xstep(desc)
+    formatter.step_started(desc)
+    formatter.step_pending
+  end
+
   context "given an empty example group" do
 
     before do
@@ -132,6 +137,29 @@ describe RSpec::Longrun::Formatter do
               (thinking) ✓ (N.NNs)
             } ✓ (N.NNs)
             Profit! ✓ (N.NNs)
+          } OK (N.NNs)
+        } (N.NNs)
+      EOF
+    end
+
+  end
+
+  context 'with xsteps' do
+
+     before do
+      example_group "suite" do
+        example "has xsteps", :passed do
+          xstep "Collect underpants" do
+          end
+        end
+      end
+    end
+
+    it "outputs steps" do
+      expect(normalized_output).to eql(<<~EOF)
+        suite {
+          has xsteps {
+            Collect underpants PENDING (N.NNs)
           } OK (N.NNs)
         } (N.NNs)
       EOF


### PR DESCRIPTION
Like rspec support skip example changing `it` by `xit` **([doc](https://relishapp.com/rspec/rspec-core/v/2-0/docs/pending/pending-examples#temporarily-pending-by-changing-%22it%22-to-%22xit%22))** I will add this feature to steps with `xstep` method.